### PR TITLE
chore(deps): bump axios in the npm_and_yarn group across 1 directory …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@phosphor-icons/react": "^2.1.7",
         "@tanstack/react-query": "^5.51.3",
         "@vercel/speed-insights": "^1.0.12",
-        "axios": "^1.7.2",
+        "axios": "^1.7.4",
         "clsx": "^2.1.1",
         "next": "14.2.5",
         "react": "^18",
@@ -3164,10 +3164,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@phosphor-icons/react": "^2.1.7",
     "@tanstack/react-query": "^5.51.3",
     "@vercel/speed-insights": "^1.0.12",
-    "axios": "^1.7.2",
+    "axios": "^1.7.4",
     "clsx": "^2.1.1",
     "next": "14.2.5",
     "react": "^18",


### PR DESCRIPTION
…(#79)

Bumps the npm_and_yarn group with 1 update in the / directory: [axios](https://github.com/axios/axios).


Updates `axios` from 1.7.2 to 1.7.4
- [Release notes](https://github.com/axios/axios/releases)
- [Changelog](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
- [Commits](https://github.com/axios/axios/compare/v1.7.2...v1.7.4)

---
updated-dependencies:
- dependency-name: axios dependency-type: direct:production dependency-group: npm_and_yarn ...