### PR TITLE
feat: implement account registration with email verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,11 @@ jobs:
         env:
           NEXT_PUBLIC_API_URL: https://api.example.com
 
+      - name: Build
+        run: pnpm build
+        env:
+          NEXT_PUBLIC_API_URL: https://api.example.com
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@v6
         env:
@@ -47,8 +52,3 @@ jobs:
         with:
           args: >
             -Dsonar.host.url=https://sonarcloud.io
-
-      - name: Build
-        run: pnpm build
-        env:
-          NEXT_PUBLIC_API_URL: https://api.example.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,13 @@ jobs:
           NEXT_PUBLIC_API_URL: https://api.example.com
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.host.url=https://sonarcloud.io
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Run linter
         run: pnpm lint
 
-      - name: Run tests
-        run: pnpm test
+      - name: Run tests with coverage
+        run: pnpm test:coverage
         env:
           NEXT_PUBLIC_API_URL: https://api.example.com
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           NEXT_PUBLIC_API_URL: https://api.example.com
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -36,6 +38,12 @@ jobs:
         run: pnpm test:coverage
         env:
           NEXT_PUBLIC_API_URL: https://api.example.com
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Build
         run: pnpm build

--- a/app/_entities/account/index.ts
+++ b/app/_entities/account/index.ts
@@ -1,0 +1,10 @@
+export type {
+  AccountRequest,
+  ConfirmEmailRequest,
+  ResendVerificationRequest,
+} from './model';
+export {
+  registerAccount,
+  requestEmailVerification,
+  confirmEmailVerification,
+} from './mutations';

--- a/app/_entities/account/model.ts
+++ b/app/_entities/account/model.ts
@@ -1,0 +1,14 @@
+export interface AccountRequest {
+  email: string;
+  phoneNumber: string;
+  password: string;
+  termsOfUserConsent: boolean;
+}
+
+export interface ConfirmEmailRequest {
+  token: string;
+}
+
+export interface ResendVerificationRequest {
+  email: string;
+}

--- a/app/_entities/account/mutations.test.ts
+++ b/app/_entities/account/mutations.test.ts
@@ -1,0 +1,119 @@
+import MockAdapter from 'axios-mock-adapter';
+import { AccountRequest } from './model';
+
+jest.mock('../../_lib/api/axios-instance', () => {
+  const axios = jest.requireActual('axios');
+  return {
+    __esModule: true,
+    default: axios.create(),
+  };
+});
+
+import api from '../../_lib/api/axios-instance';
+import {
+  registerAccount,
+  requestEmailVerification,
+  confirmEmailVerification,
+} from './mutations';
+
+describe('account mutations', () => {
+  let mockApi: MockAdapter;
+
+  const validAccountData: AccountRequest = {
+    email: 'test@test.com',
+    phoneNumber: '11999999999',
+    password: 'password123',
+    termsOfUserConsent: true,
+  };
+
+  beforeEach(() => {
+    mockApi = new MockAdapter(api);
+  });
+
+  afterEach(() => {
+    mockApi.restore();
+  });
+
+  async function expectHttpError(
+    promise: Promise<unknown>,
+    expectedStatus: number
+  ) {
+    await expect(promise).rejects.toMatchObject({
+      response: { status: expectedStatus },
+    });
+  }
+
+  describe('registerAccount', () => {
+    const endpoint = '/accounts/register';
+
+    it('calls correct endpoint with account data', async () => {
+      mockApi.onPost(endpoint).reply(201);
+
+      await registerAccount(validAccountData);
+
+      expect(mockApi.history.post[0].url).toBe(endpoint);
+      expect(JSON.parse(mockApi.history.post[0].data)).toEqual(validAccountData);
+    });
+
+    it('throws error on duplicate email (409)', async () => {
+      mockApi.onPost(endpoint).reply(409, { message: 'Email already exists' });
+      await expectHttpError(registerAccount(validAccountData), 409);
+    });
+
+    it('throws error on invalid data (400)', async () => {
+      mockApi.onPost(endpoint).reply(400, { message: 'Invalid data' });
+      await expectHttpError(
+        registerAccount({ ...validAccountData, email: 'invalid' }),
+        400
+      );
+    });
+  });
+
+  describe('requestEmailVerification', () => {
+    const endpoint = '/accounts/verifications/request';
+    const testEmail = { email: 'test@test.com' };
+
+    it('calls correct endpoint with email', async () => {
+      mockApi.onPost(endpoint).reply(200);
+
+      await requestEmailVerification(testEmail);
+
+      expect(mockApi.history.post[0].url).toBe(endpoint);
+      expect(JSON.parse(mockApi.history.post[0].data)).toEqual(testEmail);
+    });
+
+    it('throws error on email not found (404)', async () => {
+      mockApi.onPost(endpoint).reply(404, { message: 'Email not found' });
+      await expectHttpError(requestEmailVerification(testEmail), 404);
+    });
+
+    it('throws error on rate limit (429)', async () => {
+      mockApi.onPost(endpoint).reply(429, { message: 'Too many requests' });
+      await expectHttpError(requestEmailVerification(testEmail), 429);
+    });
+  });
+
+  describe('confirmEmailVerification', () => {
+    const endpoint = '/accounts/verifications/confirm';
+    const testToken = { token: 'valid-token-123' };
+
+    it('calls correct endpoint with token', async () => {
+      mockApi.onPost(endpoint).reply(200);
+
+      await confirmEmailVerification(testToken);
+
+      expect(mockApi.history.post[0].url).toBe(endpoint);
+      expect(JSON.parse(mockApi.history.post[0].data)).toEqual(testToken);
+    });
+
+    it('throws error on invalid token (400)', async () => {
+      mockApi.onPost(endpoint).reply(400, { message: 'Invalid or expired token' });
+      await expectHttpError(confirmEmailVerification({ token: 'expired-token' }), 400);
+    });
+
+    it('throws error on verification not found (404)', async () => {
+      mockApi.onPost(endpoint).reply(404, { message: 'Verification not found' });
+      await expectHttpError(confirmEmailVerification({ token: 'unknown-token' }), 404);
+    });
+  });
+});

--- a/app/_entities/account/mutations.ts
+++ b/app/_entities/account/mutations.ts
@@ -1,0 +1,22 @@
+import api from '@/app/_lib/api/axios-instance';
+import {
+  AccountRequest,
+  ConfirmEmailRequest,
+  ResendVerificationRequest,
+} from './model';
+
+export async function registerAccount(data: AccountRequest): Promise<void> {
+  await api.post('/accounts/register', data);
+}
+
+export async function requestEmailVerification(
+  data: ResendVerificationRequest
+): Promise<void> {
+  await api.post('/accounts/verifications/request', data);
+}
+
+export async function confirmEmailVerification(
+  data: ConfirmEmailRequest
+): Promise<void> {
+  await api.post('/accounts/verifications/confirm', data);
+}

--- a/app/auth/login/_components/login-form.test.tsx
+++ b/app/auth/login/_components/login-form.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthProvider } from '@/app/_lib/auth/auth-context';
+import LoginForm from './login-form';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>{children}</AuthProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('LoginForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders all form fields', () => {
+    render(<LoginForm />, { wrapper: createWrapper() });
+
+    expect(screen.getByPlaceholderText('Email')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Senha')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Entrar' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Resetar a senha' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Registrar novo abrigo' })).toBeInTheDocument();
+  });
+
+  it('submit button is disabled initially', () => {
+    render(<LoginForm />, { wrapper: createWrapper() });
+
+    const submitButton = screen.getByRole('button', { name: 'Entrar' });
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('shows validation error for invalid email', async () => {
+    const user = userEvent.setup();
+    render(<LoginForm />, { wrapper: createWrapper() });
+
+    const emailInput = screen.getByPlaceholderText('Email');
+    await user.type(emailInput, 'invalid-email');
+    await user.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText('Insira um email válido')).toBeInTheDocument();
+    });
+  });
+
+  it('shows validation error for short password', async () => {
+    const user = userEvent.setup();
+    render(<LoginForm />, { wrapper: createWrapper() });
+
+    const passwordInput = screen.getByPlaceholderText('Senha');
+    await user.type(passwordInput, '1234567');
+    await user.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText('A senha deve ter pelo menos 8 caracteres')).toBeInTheDocument();
+    });
+  });
+
+  it('navigates to reset-password when clicking "Resetar a senha"', async () => {
+    const mockPush = jest.fn();
+    jest.spyOn(require('next/navigation'), 'useRouter').mockReturnValue({
+      push: mockPush,
+    });
+
+    const user = userEvent.setup();
+    render(<LoginForm />, { wrapper: createWrapper() });
+
+    const resetButton = screen.getByRole('button', { name: 'Resetar a senha' });
+    await user.click(resetButton);
+
+    expect(mockPush).toHaveBeenCalledWith('/auth/reset-password');
+  });
+
+  it('navigates to register when clicking "Registrar novo abrigo"', async () => {
+    const mockPush = jest.fn();
+    jest.spyOn(require('next/navigation'), 'useRouter').mockReturnValue({
+      push: mockPush,
+    });
+
+    const user = userEvent.setup();
+    render(<LoginForm />, { wrapper: createWrapper() });
+
+    const registerButton = screen.getByRole('button', { name: 'Registrar novo abrigo' });
+    await user.click(registerButton);
+
+    expect(mockPush).toHaveBeenCalledWith('/auth/register');
+  });
+
+  it('all inputs have correct types', () => {
+    render(<LoginForm />, { wrapper: createWrapper() });
+
+    expect(screen.getByPlaceholderText('Email')).toHaveAttribute('type', 'email');
+    expect(screen.getByPlaceholderText('Senha')).toHaveAttribute('type', 'password');
+  });
+
+  it('all inputs have correct autocomplete attributes', () => {
+    render(<LoginForm />, { wrapper: createWrapper() });
+
+    expect(screen.getByPlaceholderText('Email')).toHaveAttribute('autocomplete', 'email');
+    expect(screen.getByPlaceholderText('Senha')).toHaveAttribute('autocomplete', 'current-password');
+  });
+});

--- a/app/auth/login/_components/login-form.test.tsx
+++ b/app/auth/login/_components/login-form.test.tsx
@@ -4,9 +4,11 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from '@/app/_lib/auth/auth-context';
 import LoginForm from './login-form';
 
+const mockPush = jest.fn();
+
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
-    push: jest.fn(),
+    push: mockPush,
   }),
 }));
 
@@ -76,11 +78,6 @@ describe('LoginForm', () => {
   });
 
   it('navigates to reset-password when clicking "Resetar a senha"', async () => {
-    const mockPush = jest.fn();
-    jest.spyOn(require('next/navigation'), 'useRouter').mockReturnValue({
-      push: mockPush,
-    });
-
     const user = userEvent.setup();
     render(<LoginForm />, { wrapper: createWrapper() });
 
@@ -91,11 +88,6 @@ describe('LoginForm', () => {
   });
 
   it('navigates to register when clicking "Registrar novo abrigo"', async () => {
-    const mockPush = jest.fn();
-    jest.spyOn(require('next/navigation'), 'useRouter').mockReturnValue({
-      push: mockPush,
-    });
-
     const user = userEvent.setup();
     render(<LoginForm />, { wrapper: createWrapper() });
 

--- a/app/auth/register/_components/register-form.test.tsx
+++ b/app/auth/register/_components/register-form.test.tsx
@@ -3,9 +3,11 @@ import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import RegisterForm from './register-form';
 
+const mockPush = jest.fn();
+
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
-    push: jest.fn(),
+    push: mockPush,
   }),
 }));
 
@@ -119,11 +121,6 @@ describe('RegisterForm', () => {
   });
 
   it('navigates to login page when clicking "Já tenho uma conta"', async () => {
-    const mockPush = jest.fn();
-    jest.spyOn(require('next/navigation'), 'useRouter').mockReturnValue({
-      push: mockPush,
-    });
-
     const user = userEvent.setup();
     render(<RegisterForm />, { wrapper: createWrapper() });
 

--- a/app/auth/register/_components/register-form.test.tsx
+++ b/app/auth/register/_components/register-form.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import RegisterForm from './register-form';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe('RegisterForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders all form fields', () => {
+    render(<RegisterForm />, { wrapper: createWrapper() });
+
+    expect(screen.getByPlaceholderText('Email')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Telefone (apenas números)')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Senha (6-16 caracteres)')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Confirme a senha')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Li e aceito os/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Criar conta' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Já tenho uma conta' })).toBeInTheDocument();
+  });
+
+  it('submit button is disabled initially', () => {
+    render(<RegisterForm />, { wrapper: createWrapper() });
+
+    const submitButton = screen.getByRole('button', { name: 'Criar conta' });
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('shows validation error for invalid email', async () => {
+    const user = userEvent.setup();
+    render(<RegisterForm />, { wrapper: createWrapper() });
+
+    const emailInput = screen.getByPlaceholderText('Email');
+    await user.type(emailInput, 'invalid-email');
+    await user.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText('Insira um email válido')).toBeInTheDocument();
+    });
+  });
+
+  it('shows validation error for short phone number', async () => {
+    const user = userEvent.setup();
+    render(<RegisterForm />, { wrapper: createWrapper() });
+
+    const phoneInput = screen.getByPlaceholderText('Telefone (apenas números)');
+    await user.type(phoneInput, '12');
+    await user.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText('O telefone deve ter pelo menos 4 dígitos')).toBeInTheDocument();
+    });
+  });
+
+  it('shows validation error for short password', async () => {
+    const user = userEvent.setup();
+    render(<RegisterForm />, { wrapper: createWrapper() });
+
+    const passwordInput = screen.getByPlaceholderText('Senha (6-16 caracteres)');
+    await user.type(passwordInput, '12345');
+    await user.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText('A senha deve ter pelo menos 6 caracteres')).toBeInTheDocument();
+    });
+  });
+
+  it('shows validation error when passwords do not match', async () => {
+    const user = userEvent.setup();
+    render(<RegisterForm />, { wrapper: createWrapper() });
+
+    const passwordInput = screen.getByPlaceholderText('Senha (6-16 caracteres)');
+    const confirmPasswordInput = screen.getByPlaceholderText('Confirme a senha');
+
+    await user.type(passwordInput, 'password123');
+    await user.type(confirmPasswordInput, 'different123');
+    await user.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText('As senhas devem ser iguais')).toBeInTheDocument();
+    });
+  });
+
+  it('renders terms of service and privacy policy links', () => {
+    render(<RegisterForm />, { wrapper: createWrapper() });
+
+    const termsLink = screen.getByRole('link', { name: 'Termos de Uso' });
+    const privacyLink = screen.getByRole('link', { name: 'Política de Privacidade' });
+
+    expect(termsLink).toHaveAttribute('href', '/terms-of-service');
+    expect(termsLink).toHaveAttribute('target', '_blank');
+    expect(termsLink).toHaveAttribute('rel', 'noopener noreferrer');
+
+    expect(privacyLink).toHaveAttribute('href', '/privacy-policy');
+    expect(privacyLink).toHaveAttribute('target', '_blank');
+    expect(privacyLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('navigates to login page when clicking "Já tenho uma conta"', async () => {
+    const mockPush = jest.fn();
+    jest.spyOn(require('next/navigation'), 'useRouter').mockReturnValue({
+      push: mockPush,
+    });
+
+    const user = userEvent.setup();
+    render(<RegisterForm />, { wrapper: createWrapper() });
+
+    const loginButton = screen.getByRole('button', { name: 'Já tenho uma conta' });
+    await user.click(loginButton);
+
+    expect(mockPush).toHaveBeenCalledWith('/auth/login');
+  });
+
+  it('checkbox can be toggled', async () => {
+    const user = userEvent.setup();
+    render(<RegisterForm />, { wrapper: createWrapper() });
+
+    const termsCheckbox = screen.getByRole('checkbox');
+    expect(termsCheckbox).not.toBeChecked();
+
+    await user.click(termsCheckbox);
+    expect(termsCheckbox).toBeChecked();
+
+    await user.click(termsCheckbox);
+    expect(termsCheckbox).not.toBeChecked();
+  });
+
+  it('form has noValidate attribute', () => {
+    render(<RegisterForm />, { wrapper: createWrapper() });
+
+    const form = document.querySelector('form');
+    expect(form).toHaveAttribute('novalidate');
+  });
+
+  it('all inputs have correct types', () => {
+    render(<RegisterForm />, { wrapper: createWrapper() });
+
+    expect(screen.getByPlaceholderText('Email')).toHaveAttribute('type', 'email');
+    expect(screen.getByPlaceholderText('Telefone (apenas números)')).toHaveAttribute('type', 'tel');
+    expect(screen.getByPlaceholderText('Senha (6-16 caracteres)')).toHaveAttribute('type', 'password');
+    expect(screen.getByPlaceholderText('Confirme a senha')).toHaveAttribute('type', 'password');
+  });
+
+  it('all inputs have correct autocomplete attributes', () => {
+    render(<RegisterForm />, { wrapper: createWrapper() });
+
+    expect(screen.getByPlaceholderText('Email')).toHaveAttribute('autocomplete', 'email');
+    expect(screen.getByPlaceholderText('Telefone (apenas números)')).toHaveAttribute('autocomplete', 'tel');
+    expect(screen.getByPlaceholderText('Senha (6-16 caracteres)')).toHaveAttribute('autocomplete', 'new-password');
+    expect(screen.getByPlaceholderText('Confirme a senha')).toHaveAttribute('autocomplete', 'new-password');
+  });
+});

--- a/app/auth/register/_components/register-form.tsx
+++ b/app/auth/register/_components/register-form.tsx
@@ -1,118 +1,234 @@
 'use client';
 
 import {
-  BuildingOffice,
   Envelope,
-  FilePlus,
-  IdentificationCard,
   LockSimple,
-  User,
+  Phone,
+  UserPlus,
 } from '@phosphor-icons/react/dist/ssr';
 import { zodResolver } from '@hookform/resolvers/zod';
 import Button from '@/app/_components/ui/button';
 import Input from '@/app/_components/ui/input';
-import { useForm } from 'react-hook-form';
-import { string, z } from 'zod';
-
-const registerSchema = z
-  .object({
-    shelterName: string().min(4, 'O nome deve ter pelo menos 4 caracteres'),
-    responsibleName: string().min(4, 'O nome deve ter pelo menos 4 caracteres'),
-    responsibleCPF: string().min(11, 'O CPF deve ter pelo menos 11 digitos'),
-    email: string().email('Insira um email válido'),
-    password: string().min(8, 'A senha deve ter pelo menos 8 caracteres'),
-    confirmPassword: string(),
-  })
-  .refine((data) => data.password === data.confirmPassword, {
-    message: 'As senhas devem ser iguais',
-    path: ['confirmPassword'],
-  });
+import { useRegister } from '../_hooks/use-register';
+import { useForm, Controller } from 'react-hook-form';
+import { useRouter } from 'next/navigation';
+import { useState, useRef } from 'react';
+import { AxiosError } from 'axios';
+import {
+  registerSchema,
+  RegisterFormData,
+} from '../_config/register-schema';
+import Link from 'next/link';
 
 export default function RegisterForm() {
+  const router = useRouter();
+  const [apiError, setApiError] = useState<string | null>(null);
+  const pendingEmailRef = useRef<string>('');
+
+  const { mutate: registerMutate, isPending } = useRegister({
+    onSuccess: () => {
+      const encodedEmail = encodeURIComponent(pendingEmailRef.current);
+      router.push(`/auth/verification-pending?email=${encodedEmail}`);
+    },
+    onError: (error) => {
+      if (error instanceof AxiosError) {
+        if (error.response?.status === 409) {
+          setApiError('Este email já está cadastrado');
+        } else if (error.response?.status === 400) {
+          setApiError('Dados inválidos. Verifique os campos.');
+        } else if (error.response?.status === 429) {
+          setApiError('Muitas tentativas. Aguarde antes de tentar novamente.');
+        } else {
+          setApiError('Erro ao criar conta. Tente novamente.');
+        }
+      } else {
+        setApiError('Erro ao criar conta. Tente novamente.');
+      }
+    },
+  });
+
   const {
     register,
     handleSubmit,
-    formState: { errors, isLoading, isValid },
-  } = useForm<registerData>({
-    mode: 'all',
+    control,
+    formState: { errors, isValid },
+  } = useForm<RegisterFormData>({
+    mode: 'onBlur',
     criteriaMode: 'all',
     resolver: zodResolver(registerSchema),
+    defaultValues: {
+      termsOfUserConsent: false,
+    },
   });
 
-  type registerData = z.infer<typeof registerSchema>;
-
-  function handleRegister(_data: registerData) {
-    // TODO: Implement registration API call
+  function handleRegister(data: RegisterFormData) {
+    setApiError(null);
+    pendingEmailRef.current = data.email;
+    registerMutate({
+      email: data.email,
+      phoneNumber: data.phoneNumber,
+      password: data.password,
+      termsOfUserConsent: data.termsOfUserConsent,
+    });
   }
+
+  function clearApiError() {
+    if (apiError) {
+      setApiError(null);
+    }
+  }
+
+  const emailRegister = register('email');
+  const phoneRegister = register('phoneNumber');
+  const passwordRegister = register('password');
+  const confirmPasswordRegister = register('confirmPassword');
+
   return (
     <form
+      noValidate
       onSubmit={handleSubmit(handleRegister)}
       className='mt-8 flex w-full max-w-[467px] flex-col gap-4 lg:gap-8'
     >
       <Input
-        id='shelter-name'
-        placeholder='Nome do abrigo'
-        type='text'
-        className='w-full max-w-[467px]'
-        icon={<BuildingOffice size={28} className='text-content-200/75' />}
-        errorMessage={errors.shelterName?.message}
-        {...register('shelterName')}
-      />
-      <Input
-        id='responsible-name'
-        placeholder='Nome do responsável'
-        type='text'
-        className='w-full max-w-[467px]'
-        icon={<User size={28} className='text-content-200/75' />}
-        errorMessage={errors.responsibleName?.message}
-        {...register('responsibleName')}
-      />
-      <Input
-        id='responsible-cpf'
-        placeholder='CPF do responsável'
-        type='text'
-        className='w-full max-w-[467px]'
-        icon={<IdentificationCard size={28} className='text-content-200/75' />}
-        errorMessage={errors.responsibleCPF?.message}
-        {...register('responsibleCPF')}
-      />
-      <Input
         id='email'
         placeholder='Email'
         type='email'
+        autoComplete='email'
         className='w-full max-w-[467px]'
         icon={<Envelope size={28} className='text-content-200/75' />}
         errorMessage={errors.email?.message}
-        {...register('email')}
+        disabled={isPending}
+        {...emailRegister}
+        onChange={(e) => {
+          clearApiError();
+          emailRegister.onChange(e);
+        }}
+      />
+      <Input
+        id='phone-number'
+        placeholder='Telefone (apenas números)'
+        type='tel'
+        autoComplete='tel'
+        className='w-full max-w-[467px]'
+        icon={<Phone size={28} className='text-content-200/75' />}
+        errorMessage={errors.phoneNumber?.message}
+        disabled={isPending}
+        {...phoneRegister}
+        onChange={(e) => {
+          clearApiError();
+          phoneRegister.onChange(e);
+        }}
       />
       <Input
         id='password'
-        placeholder='Senha'
+        placeholder='Senha (6-16 caracteres)'
         type='password'
+        autoComplete='new-password'
         className='w-full max-w-[467px]'
         icon={<LockSimple size={28} className='text-content-200/75' />}
         errorMessage={errors.password?.message}
-        {...register('password')}
+        disabled={isPending}
+        {...passwordRegister}
+        onChange={(e) => {
+          clearApiError();
+          passwordRegister.onChange(e);
+        }}
       />
       <Input
         id='confirm-password'
         placeholder='Confirme a senha'
         type='password'
+        autoComplete='new-password'
         className='w-full max-w-[467px]'
         icon={<LockSimple size={28} className='text-content-200/75' />}
         errorMessage={errors.confirmPassword?.message}
-        {...register('confirmPassword')}
+        disabled={isPending}
+        {...confirmPasswordRegister}
+        onChange={(e) => {
+          clearApiError();
+          confirmPasswordRegister.onChange(e);
+        }}
       />
 
-      <Button
-        type='submit'
-        aria-label='Cadastrar novo abrigo'
-        label='Cadastrar novo abrigo'
-        className='mt-4 w-full lg:mt-0 lg:w-72'
-        icon={<FilePlus size={28} />}
-        isLoading={isLoading}
-        disabled={!isValid}
-      />
+      <div className='flex flex-col gap-2'>
+        <div className='flex items-start gap-3'>
+          <Controller
+            name='termsOfUserConsent'
+            control={control}
+            render={({ field }) => (
+              <input
+                type='checkbox'
+                id='terms'
+                checked={field.value}
+                onChange={(e) => {
+                  clearApiError();
+                  field.onChange(e.target.checked);
+                }}
+                disabled={isPending}
+                className='mt-1 h-5 w-5 cursor-pointer rounded border-content-200 accent-accent'
+              />
+            )}
+          />
+          <label htmlFor='terms' className='cursor-pointer text-sm text-content-300'>
+            Li e aceito os{' '}
+            <Link
+              href='/terms-of-service'
+              className='text-accent underline hover:text-secondary'
+              target='_blank'
+              rel='noopener noreferrer'
+              prefetch={false}
+            >
+              Termos de Uso
+            </Link>{' '}
+            e a{' '}
+            <Link
+              href='/privacy-policy'
+              className='text-accent underline hover:text-secondary'
+              target='_blank'
+              rel='noopener noreferrer'
+              prefetch={false}
+            >
+              Política de Privacidade
+            </Link>
+          </label>
+        </div>
+        {errors.termsOfUserConsent && (
+          <p className='ms-3 text-sm text-error'>
+            {errors.termsOfUserConsent.message}
+          </p>
+        )}
+      </div>
+
+      {apiError && (
+        <p className='text-center text-sm text-error' role='alert' aria-live='polite'>
+          {apiError}
+        </p>
+      )}
+
+      <div className='flex flex-col items-center justify-center gap-4'>
+        <Button
+          type='submit'
+          aria-label='Criar conta'
+          label='Criar conta'
+          className='w-full lg:w-72'
+          icon={<UserPlus size={28} />}
+          isLoading={isPending}
+          disabled={!isValid || isPending}
+        />
+        <Button
+          type='button'
+          aria-label='Já tenho uma conta'
+          label='Já tenho uma conta'
+          className='mb-10 w-full lg:mb-auto lg:w-72'
+          outline
+          disabled={isPending}
+          onClick={() => {
+            if (!isPending) {
+              router.push('/auth/login');
+            }
+          }}
+        />
+      </div>
     </form>
   );
 }

--- a/app/auth/register/_config/register-schema.test.ts
+++ b/app/auth/register/_config/register-schema.test.ts
@@ -1,0 +1,130 @@
+import { registerSchema } from './register-schema';
+
+describe('registerSchema', () => {
+  const validData = {
+    email: 'test@example.com',
+    phoneNumber: '11999999999',
+    password: 'password123',
+    confirmPassword: 'password123',
+    termsOfUserConsent: true,
+  };
+
+  function expectValidationError(
+    data: Partial<typeof validData>,
+    field: string,
+    expectedMessage: string
+  ) {
+    const result = registerSchema.safeParse({ ...validData, ...data });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain(field);
+      expect(result.error.issues[0].message).toBe(expectedMessage);
+    }
+  }
+
+  function expectValidationSuccess(data: Partial<typeof validData>) {
+    const result = registerSchema.safeParse({ ...validData, ...data });
+    expect(result.success).toBe(true);
+  }
+
+  it('validates correct data', () => {
+    const result = registerSchema.safeParse(validData);
+    expect(result.success).toBe(true);
+  });
+
+  describe('email validation', () => {
+    it('rejects invalid email', () => {
+      expectValidationError({ email: 'invalid-email' }, 'email', 'Insira um email válido');
+    });
+
+    it('rejects empty email', () => {
+      const result = registerSchema.safeParse({ ...validData, email: '' });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('phoneNumber validation', () => {
+    it('accepts 4-digit phone number', () => {
+      expectValidationSuccess({ phoneNumber: '1234' });
+    });
+
+    it('accepts 20-digit phone number', () => {
+      expectValidationSuccess({ phoneNumber: '12345678901234567890' });
+    });
+
+    it('rejects phone number with less than 4 digits', () => {
+      expectValidationError(
+        { phoneNumber: '123' },
+        'phoneNumber',
+        'O telefone deve ter pelo menos 4 dígitos'
+      );
+    });
+
+    it('rejects phone number with more than 20 digits', () => {
+      expectValidationError(
+        { phoneNumber: '123456789012345678901' },
+        'phoneNumber',
+        'O telefone deve ter no máximo 20 dígitos'
+      );
+    });
+
+    it('rejects phone number with non-numeric characters', () => {
+      expectValidationError(
+        { phoneNumber: '1199-9999-999' },
+        'phoneNumber',
+        'O telefone deve conter apenas números'
+      );
+    });
+
+    it('rejects phone number with letters', () => {
+      const result = registerSchema.safeParse({ ...validData, phoneNumber: '11999abc999' });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('password validation', () => {
+    it('accepts 6-character password', () => {
+      expectValidationSuccess({ password: '123456', confirmPassword: '123456' });
+    });
+
+    it('accepts 16-character password', () => {
+      expectValidationSuccess({ password: '1234567890123456', confirmPassword: '1234567890123456' });
+    });
+
+    it('rejects password with less than 6 characters', () => {
+      expectValidationError(
+        { password: '12345', confirmPassword: '12345' },
+        'password',
+        'A senha deve ter pelo menos 6 caracteres'
+      );
+    });
+
+    it('rejects password with more than 16 characters', () => {
+      expectValidationError(
+        { password: '12345678901234567', confirmPassword: '12345678901234567' },
+        'password',
+        'A senha deve ter no máximo 16 caracteres'
+      );
+    });
+  });
+
+  describe('confirmPassword validation', () => {
+    it('rejects when passwords do not match', () => {
+      expectValidationError(
+        { password: 'password123', confirmPassword: 'password456' },
+        'confirmPassword',
+        'As senhas devem ser iguais'
+      );
+    });
+  });
+
+  describe('termsOfUserConsent validation', () => {
+    it('rejects when terms are not accepted', () => {
+      expectValidationError(
+        { termsOfUserConsent: false },
+        'termsOfUserConsent',
+        'Você deve aceitar os termos de uso'
+      );
+    });
+  });
+});

--- a/app/auth/register/_config/register-schema.ts
+++ b/app/auth/register/_config/register-schema.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const registerSchema = z
+  .object({
+    email: z.string().email('Insira um email válido'),
+    phoneNumber: z
+      .string()
+      .min(4, 'O telefone deve ter pelo menos 4 dígitos')
+      .max(20, 'O telefone deve ter no máximo 20 dígitos')
+      .regex(/^\d+$/, 'O telefone deve conter apenas números'),
+    password: z
+      .string()
+      .min(6, 'A senha deve ter pelo menos 6 caracteres')
+      .max(16, 'A senha deve ter no máximo 16 caracteres'),
+    confirmPassword: z.string(),
+    termsOfUserConsent: z
+      .boolean()
+      .refine((val) => val === true, {
+        message: 'Você deve aceitar os termos de uso',
+      }),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: 'As senhas devem ser iguais',
+    path: ['confirmPassword'],
+  });
+
+export type RegisterFormData = z.infer<typeof registerSchema>;

--- a/app/auth/register/_hooks/use-register.test.tsx
+++ b/app/auth/register/_hooks/use-register.test.tsx
@@ -1,0 +1,135 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useRegister } from './use-register';
+import * as accountMutations from '../../../_entities/account/mutations';
+import { AxiosError } from 'axios';
+import { ReactNode } from 'react';
+
+jest.mock('../../../_entities/account/mutations');
+
+const mockAccountMutations = accountMutations as jest.Mocked<typeof accountMutations>;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe('useRegister', () => {
+  const validAccountData = {
+    email: 'test@test.com',
+    phoneNumber: '11999999999',
+    password: 'password123',
+    termsOfUserConsent: true as const,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls registerAccount mutation on success', async () => {
+    mockAccountMutations.registerAccount.mockResolvedValue(undefined);
+
+    const onSuccess = jest.fn();
+    const { result } = renderHook(() => useRegister({ onSuccess }), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate(validAccountData);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockAccountMutations.registerAccount).toHaveBeenCalledWith(validAccountData);
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('calls onError callback on failure', async () => {
+    const axiosError = new AxiosError('Conflict');
+    axiosError.response = { status: 409 } as AxiosError['response'];
+    mockAccountMutations.registerAccount.mockRejectedValue(axiosError);
+
+    const onError = jest.fn();
+    const { result } = renderHook(() => useRegister({ onError }), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate(validAccountData);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(onError).toHaveBeenCalledWith(axiosError);
+  });
+
+  it('returns isPending true while mutation is in progress', async () => {
+    let resolveRegister: (value: unknown) => void;
+    mockAccountMutations.registerAccount.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRegister = resolve;
+        })
+    );
+
+    const { result } = renderHook(() => useRegister(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate(validAccountData);
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(true);
+    });
+
+    resolveRegister!(undefined);
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+  });
+
+  it('handles network errors', async () => {
+    mockAccountMutations.registerAccount.mockRejectedValue(new Error('Network error'));
+
+    const onError = jest.fn();
+    const { result } = renderHook(() => useRegister({ onError }), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate(validAccountData);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it('does not call onSuccess on failure', async () => {
+    mockAccountMutations.registerAccount.mockRejectedValue(new Error('Error'));
+
+    const onSuccess = jest.fn();
+    const { result } = renderHook(() => useRegister({ onSuccess }), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate(validAccountData);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/app/auth/register/_hooks/use-register.ts
+++ b/app/auth/register/_hooks/use-register.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import { registerAccount } from '@/app/_entities/account/mutations';
+import { AccountRequest } from '@/app/_entities/account/model';
+
+interface UseRegisterOptions {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+}
+
+export function useRegister(options?: UseRegisterOptions) {
+  return useMutation({
+    mutationFn: (data: AccountRequest) => registerAccount(data),
+    onSuccess: () => {
+      options?.onSuccess?.();
+    },
+    onError: (error: Error) => {
+      options?.onError?.(error);
+    },
+  });
+}

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -4,9 +4,9 @@ import HorizontalLayout from '@/app/_components/horizontal-layout';
 export default function RegisterPage() {
   return (
     <HorizontalLayout>
-      <h1 className='text-3xl font-bold text-accent sm:text-4xl'>Bem-vindo</h1>
+      <h1 className='text-3xl font-bold text-accent sm:text-4xl'>Criar conta</h1>
       <p className='mt-2 text-content-300 sm:text-lg'>
-        Crie sua conta de novo abrigo
+        Preencha os dados abaixo para criar sua conta
       </p>
       <RegisterForm />
     </HorizontalLayout>

--- a/app/auth/verification-pending/_components/verification-pending-content.test.tsx
+++ b/app/auth/verification-pending/_components/verification-pending-content.test.tsx
@@ -1,0 +1,203 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import VerificationPendingContent from './verification-pending-content';
+import * as accountMutations from '../../../_entities/account/mutations';
+import { AxiosError } from 'axios';
+
+jest.mock('../../../_entities/account/mutations');
+
+const mockPush = jest.fn();
+const mockGet = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+  useSearchParams: () => ({
+    get: mockGet,
+  }),
+}));
+
+const mockAccountMutations = accountMutations as jest.Mocked<typeof accountMutations>;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe('VerificationPendingContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGet.mockReturnValue(null);
+  });
+
+  it('renders the verification pending message', () => {
+    render(<VerificationPendingContent />, { wrapper: createWrapper() });
+
+    expect(screen.getByText('Verifique seu email')).toBeInTheDocument();
+    expect(screen.getByText(/Enviamos um link de verificação/)).toBeInTheDocument();
+  });
+
+  it('renders email input and resend button', () => {
+    render(<VerificationPendingContent />, { wrapper: createWrapper() });
+
+    expect(screen.getByPlaceholderText('Seu email')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reenviar email de verificação' })).toBeInTheDocument();
+  });
+
+  it('pre-fills email from query parameter', () => {
+    mockGet.mockReturnValue('test@example.com');
+
+    render(<VerificationPendingContent />, { wrapper: createWrapper() });
+
+    const emailInput = screen.getByPlaceholderText('Seu email') as HTMLInputElement;
+    expect(emailInput.value).toBe('test@example.com');
+  });
+
+  it('shows validation error for invalid email', async () => {
+    const user = userEvent.setup();
+    render(<VerificationPendingContent />, { wrapper: createWrapper() });
+
+    const emailInput = screen.getByPlaceholderText('Seu email');
+    await user.type(emailInput, 'invalid-email');
+    await user.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText('Insira um email válido')).toBeInTheDocument();
+    });
+  });
+
+  it('calls requestEmailVerification on valid form submission', async () => {
+    mockAccountMutations.requestEmailVerification.mockResolvedValue(undefined);
+
+    const user = userEvent.setup();
+    render(<VerificationPendingContent />, { wrapper: createWrapper() });
+
+    const emailInput = screen.getByPlaceholderText('Seu email');
+
+    await user.type(emailInput, 'test@test.com');
+    await user.tab();
+
+    const submitButton = screen.getByRole('button', { name: 'Reenviar email de verificação' });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockAccountMutations.requestEmailVerification).toHaveBeenCalledWith({
+        email: 'test@test.com',
+      });
+    });
+  });
+
+  it('shows success message after resending email', async () => {
+    mockAccountMutations.requestEmailVerification.mockResolvedValue(undefined);
+
+    const user = userEvent.setup();
+    render(<VerificationPendingContent />, { wrapper: createWrapper() });
+
+    const emailInput = screen.getByPlaceholderText('Seu email');
+
+    await user.type(emailInput, 'test@test.com');
+    await user.tab();
+
+    const submitButton = screen.getByRole('button', { name: 'Reenviar email de verificação' });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Email de verificação reenviado com sucesso!')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error message on email not found (404)', async () => {
+    const axiosError = new AxiosError('Not Found');
+    axiosError.response = { status: 404 } as AxiosError['response'];
+    mockAccountMutations.requestEmailVerification.mockRejectedValue(axiosError);
+
+    const user = userEvent.setup();
+    render(<VerificationPendingContent />, { wrapper: createWrapper() });
+
+    const emailInput = screen.getByPlaceholderText('Seu email');
+
+    await user.type(emailInput, 'notfound@test.com');
+    await user.tab();
+
+    const submitButton = screen.getByRole('button', { name: 'Reenviar email de verificação' });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Email não encontrado. Verifique se digitou corretamente.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error message on rate limit (429)', async () => {
+    const axiosError = new AxiosError('Too Many Requests');
+    axiosError.response = { status: 429 } as AxiosError['response'];
+    mockAccountMutations.requestEmailVerification.mockRejectedValue(axiosError);
+
+    const user = userEvent.setup();
+    render(<VerificationPendingContent />, { wrapper: createWrapper() });
+
+    const emailInput = screen.getByPlaceholderText('Seu email');
+
+    await user.type(emailInput, 'test@test.com');
+    await user.tab();
+
+    const submitButton = screen.getByRole('button', { name: 'Reenviar email de verificação' });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Muitas tentativas. Aguarde antes de tentar novamente.')).toBeInTheDocument();
+    });
+  });
+
+  it('navigates to login when clicking "Ir para login"', async () => {
+    const user = userEvent.setup();
+    render(<VerificationPendingContent />, { wrapper: createWrapper() });
+
+    const loginButton = screen.getByRole('button', { name: 'Ir para login' });
+    await user.click(loginButton);
+
+    expect(mockPush).toHaveBeenCalledWith('/auth/login');
+  });
+
+  it('disables submit button while submitting', async () => {
+    let resolveResend: (value: unknown) => void;
+    mockAccountMutations.requestEmailVerification.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveResend = resolve;
+        })
+    );
+
+    const user = userEvent.setup();
+    render(<VerificationPendingContent />, { wrapper: createWrapper() });
+
+    const emailInput = screen.getByPlaceholderText('Seu email');
+
+    await user.type(emailInput, 'test@test.com');
+    await user.tab();
+
+    const submitButton = screen.getByRole('button', { name: 'Reenviar email de verificação' });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(submitButton).toBeDisabled();
+    });
+
+    resolveResend!(undefined);
+
+    await waitFor(() => {
+      expect(submitButton).not.toBeDisabled();
+    });
+  });
+});

--- a/app/auth/verification-pending/_components/verification-pending-content.tsx
+++ b/app/auth/verification-pending/_components/verification-pending-content.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useState } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import {
+  EnvelopeSimple,
+  PaperPlaneTilt,
+  CheckCircle,
+  SignIn,
+} from '@phosphor-icons/react';
+import Button from '@/app/_components/ui/button';
+import Input from '@/app/_components/ui/input';
+import { useResendVerification } from '../_hooks/use-resend-verification';
+import { AxiosError } from 'axios';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { resendSchema, ResendFormData } from '../_config/resend-schema';
+
+export default function VerificationPendingContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const emailFromQuery = searchParams.get('email') || '';
+
+  const [feedback, setFeedback] = useState<{
+    type: 'success' | 'error';
+    message: string;
+  } | null>(null);
+
+  const { mutate: resendEmail, isPending } = useResendVerification({
+    onSuccess: () => {
+      setFeedback({
+        type: 'success',
+        message: 'Email de verificação reenviado com sucesso!',
+      });
+    },
+    onError: (error) => {
+      if (error instanceof AxiosError) {
+        if (error.response?.status === 404) {
+          setFeedback({
+            type: 'error',
+            message: 'Email não encontrado. Verifique se digitou corretamente.',
+          });
+        } else if (error.response?.status === 429) {
+          setFeedback({
+            type: 'error',
+            message: 'Muitas tentativas. Aguarde antes de tentar novamente.',
+          });
+        } else {
+          setFeedback({
+            type: 'error',
+            message: 'Erro ao reenviar email. Tente novamente.',
+          });
+        }
+      } else {
+        setFeedback({
+          type: 'error',
+          message: 'Erro ao reenviar email. Tente novamente.',
+        });
+      }
+    },
+  });
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<ResendFormData>({
+    mode: 'onBlur',
+    resolver: zodResolver(resendSchema),
+    defaultValues: {
+      email: emailFromQuery,
+    },
+  });
+
+  function handleResend(data: ResendFormData) {
+    setFeedback(null);
+    resendEmail({ email: data.email });
+  }
+
+  return (
+    <div className='flex w-full max-w-[467px] flex-col items-center text-center'>
+      <EnvelopeSimple size={64} className='mb-6 text-accent' weight='fill' />
+      <h1 className='text-2xl font-bold text-accent sm:text-3xl'>
+        Verifique seu email
+      </h1>
+      <p className='mt-2 text-content-300'>
+        Enviamos um link de verificação para o seu email. Clique no link para
+        ativar sua conta.
+      </p>
+      <p className='mt-4 text-sm text-content-200'>
+        Não recebeu o email? Verifique sua caixa de spam ou solicite um novo
+        link abaixo.
+      </p>
+
+      <form
+        noValidate
+        onSubmit={handleSubmit(handleResend)}
+        className='mt-8 flex w-full flex-col gap-4'
+      >
+        <Input
+          id='email'
+          placeholder='Seu email'
+          type='email'
+          autoComplete='email'
+          className='w-full'
+          icon={<EnvelopeSimple size={28} className='text-content-200/75' />}
+          errorMessage={errors.email?.message}
+          disabled={isPending}
+          {...register('email')}
+        />
+
+        {feedback && (
+          <div
+            className={`flex items-center justify-center gap-2 text-sm ${
+              feedback.type === 'success' ? 'text-success' : 'text-error'
+            }`}
+            role='alert'
+            aria-live='polite'
+          >
+            {feedback.type === 'success' && <CheckCircle size={20} weight='fill' />}
+            {feedback.message}
+          </div>
+        )}
+
+        <Button
+          type='submit'
+          aria-label='Reenviar email de verificação'
+          label='Reenviar email'
+          className='w-full lg:w-72 lg:self-center'
+          icon={<PaperPlaneTilt size={28} />}
+          isLoading={isPending}
+          disabled={!isValid || isPending}
+        />
+      </form>
+
+      <Button
+        type='button'
+        aria-label='Ir para login'
+        label='Ir para login'
+        className='mt-4 w-full lg:w-72'
+        outline
+        icon={<SignIn size={28} />}
+        onClick={() => router.push('/auth/login')}
+      />
+    </div>
+  );
+}

--- a/app/auth/verification-pending/_config/resend-schema.test.ts
+++ b/app/auth/verification-pending/_config/resend-schema.test.ts
@@ -1,0 +1,27 @@
+import { resendSchema } from './resend-schema';
+
+describe('resendSchema', () => {
+  it('validates correct email', () => {
+    const result = resendSchema.safeParse({ email: 'test@example.com' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid email', () => {
+    const result = resendSchema.safeParse({ email: 'invalid-email' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('email');
+      expect(result.error.issues[0].message).toBe('Insira um email válido');
+    }
+  });
+
+  it('rejects empty email', () => {
+    const result = resendSchema.safeParse({ email: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing email', () => {
+    const result = resendSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});

--- a/app/auth/verification-pending/_config/resend-schema.ts
+++ b/app/auth/verification-pending/_config/resend-schema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const resendSchema = z.object({
+  email: z.string().email('Insira um email válido'),
+});
+
+export type ResendFormData = z.infer<typeof resendSchema>;

--- a/app/auth/verification-pending/_hooks/use-resend-verification.test.tsx
+++ b/app/auth/verification-pending/_hooks/use-resend-verification.test.tsx
@@ -1,0 +1,113 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useResendVerification } from './use-resend-verification';
+import * as accountMutations from '../../../_entities/account/mutations';
+import { AxiosError } from 'axios';
+import { ReactNode } from 'react';
+
+jest.mock('../../../_entities/account/mutations');
+
+const mockAccountMutations = accountMutations as jest.Mocked<typeof accountMutations>;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe('useResendVerification', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls requestEmailVerification mutation on success', async () => {
+    mockAccountMutations.requestEmailVerification.mockResolvedValue(undefined);
+
+    const onSuccess = jest.fn();
+    const { result } = renderHook(() => useResendVerification({ onSuccess }), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ email: 'test@test.com' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockAccountMutations.requestEmailVerification).toHaveBeenCalledWith({
+      email: 'test@test.com',
+    });
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('calls onError callback on failure', async () => {
+    const axiosError = new AxiosError('Not Found');
+    axiosError.response = { status: 404 } as AxiosError['response'];
+    mockAccountMutations.requestEmailVerification.mockRejectedValue(axiosError);
+
+    const onError = jest.fn();
+    const { result } = renderHook(() => useResendVerification({ onError }), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ email: 'notfound@test.com' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(onError).toHaveBeenCalledWith(axiosError);
+  });
+
+  it('returns isPending true while mutation is in progress', async () => {
+    let resolveResend: (value: unknown) => void;
+    mockAccountMutations.requestEmailVerification.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveResend = resolve;
+        })
+    );
+
+    const { result } = renderHook(() => useResendVerification(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ email: 'test@test.com' });
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(true);
+    });
+
+    resolveResend!(undefined);
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+  });
+
+  it('does not call onSuccess on failure', async () => {
+    mockAccountMutations.requestEmailVerification.mockRejectedValue(new Error('Error'));
+
+    const onSuccess = jest.fn();
+    const { result } = renderHook(() => useResendVerification({ onSuccess }), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ email: 'test@test.com' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/app/auth/verification-pending/_hooks/use-resend-verification.ts
+++ b/app/auth/verification-pending/_hooks/use-resend-verification.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import { requestEmailVerification } from '@/app/_entities/account/mutations';
+import { ResendVerificationRequest } from '@/app/_entities/account/model';
+
+interface UseResendVerificationOptions {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+}
+
+export function useResendVerification(options?: UseResendVerificationOptions) {
+  return useMutation({
+    mutationFn: (data: ResendVerificationRequest) => requestEmailVerification(data),
+    onSuccess: () => {
+      options?.onSuccess?.();
+    },
+    onError: (error: Error) => {
+      options?.onError?.(error);
+    },
+  });
+}

--- a/app/auth/verification-pending/page.tsx
+++ b/app/auth/verification-pending/page.tsx
@@ -1,0 +1,26 @@
+import { Suspense } from 'react';
+import { EnvelopeSimple } from '@phosphor-icons/react/dist/ssr';
+import HorizontalLayout from '@/app/_components/horizontal-layout';
+import VerificationPendingContent from './_components/verification-pending-content';
+
+function LoadingFallback() {
+  return (
+    <div className='flex w-full max-w-[467px] flex-col items-center text-center'>
+      <EnvelopeSimple size={64} className='mb-6 text-accent' weight='fill' />
+      <h1 className='text-2xl font-bold text-accent sm:text-3xl'>
+        Verifique seu email
+      </h1>
+      <p className='mt-2 text-content-300'>Carregando...</p>
+    </div>
+  );
+}
+
+export default function VerificationPendingPage() {
+  return (
+    <HorizontalLayout>
+      <Suspense fallback={<LoadingFallback />}>
+        <VerificationPendingContent />
+      </Suspense>
+    </HorizontalLayout>
+  );
+}

--- a/app/auth/verify-email/_components/verify-email-content.test.tsx
+++ b/app/auth/verify-email/_components/verify-email-content.test.tsx
@@ -1,0 +1,163 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import VerifyEmailContent from './verify-email-content';
+import * as accountMutations from '../../../_entities/account/mutations';
+import { AxiosError } from 'axios';
+
+jest.mock('../../../_entities/account/mutations');
+
+const mockPush = jest.fn();
+const mockGet = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+  useSearchParams: () => ({
+    get: mockGet,
+  }),
+}));
+
+const mockAccountMutations = accountMutations as jest.Mocked<typeof accountMutations>;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe('VerifyEmailContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGet.mockReturnValue(null);
+  });
+
+  it('shows error when token is missing', async () => {
+    mockGet.mockReturnValue(null);
+
+    render(<VerifyEmailContent />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Erro na verificação')).toBeInTheDocument();
+      expect(screen.getByText('Token de verificação não encontrado.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error when token format is invalid', async () => {
+    mockGet.mockReturnValue('<script>alert("xss")</script>');
+
+    render(<VerifyEmailContent />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Erro na verificação')).toBeInTheDocument();
+      expect(screen.getByText('Formato de token inválido.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows loading state while verifying', async () => {
+    mockGet.mockReturnValue('valid-token-123');
+    mockAccountMutations.confirmEmailVerification.mockImplementation(
+      () => new Promise(() => {})
+    );
+
+    render(<VerifyEmailContent />, { wrapper: createWrapper() });
+
+    expect(screen.getByText('Verificando seu email...')).toBeInTheDocument();
+  });
+
+  it('shows success state after verification', async () => {
+    mockGet.mockReturnValue('valid-token-123');
+    mockAccountMutations.confirmEmailVerification.mockResolvedValue(undefined);
+
+    render(<VerifyEmailContent />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Email verificado!')).toBeInTheDocument();
+      expect(screen.getByText('Sua conta foi verificada com sucesso. Você já pode fazer login.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state on invalid token (400)', async () => {
+    mockGet.mockReturnValue('expired-token');
+    const axiosError = new AxiosError('Bad Request');
+    axiosError.response = { status: 400 } as AxiosError['response'];
+    mockAccountMutations.confirmEmailVerification.mockRejectedValue(axiosError);
+
+    render(<VerifyEmailContent />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Erro na verificação')).toBeInTheDocument();
+      expect(screen.getByText('Token inválido ou expirado.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state on verification not found (404)', async () => {
+    mockGet.mockReturnValue('unknown-token');
+    const axiosError = new AxiosError('Not Found');
+    axiosError.response = { status: 404 } as AxiosError['response'];
+    mockAccountMutations.confirmEmailVerification.mockRejectedValue(axiosError);
+
+    render(<VerifyEmailContent />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Erro na verificação')).toBeInTheDocument();
+      expect(screen.getByText('Verificação não encontrada.')).toBeInTheDocument();
+    });
+  });
+
+  it('navigates to login when clicking button after success', async () => {
+    mockGet.mockReturnValue('valid-token-123');
+    mockAccountMutations.confirmEmailVerification.mockResolvedValue(undefined);
+
+    const user = userEvent.setup();
+    render(<VerifyEmailContent />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Email verificado!')).toBeInTheDocument();
+    });
+
+    const loginButton = screen.getByRole('button', { name: 'Ir para login' });
+    await user.click(loginButton);
+
+    expect(mockPush).toHaveBeenCalledWith('/auth/login');
+  });
+
+  it('navigates to login when clicking button after error', async () => {
+    mockGet.mockReturnValue(null);
+
+    const user = userEvent.setup();
+    render(<VerifyEmailContent />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Erro na verificação')).toBeInTheDocument();
+    });
+
+    const loginButton = screen.getByRole('button', { name: 'Ir para login' });
+    await user.click(loginButton);
+
+    expect(mockPush).toHaveBeenCalledWith('/auth/login');
+  });
+
+  it('calls confirmEmailVerification with correct token', async () => {
+    mockGet.mockReturnValue('my-valid-token');
+    mockAccountMutations.confirmEmailVerification.mockResolvedValue(undefined);
+
+    render(<VerifyEmailContent />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(mockAccountMutations.confirmEmailVerification).toHaveBeenCalledWith({
+        token: 'my-valid-token',
+      });
+    });
+  });
+});

--- a/app/auth/verify-email/_components/verify-email-content.tsx
+++ b/app/auth/verify-email/_components/verify-email-content.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useEffect, useState, useRef } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { CheckCircle, XCircle, SignIn } from '@phosphor-icons/react';
+import Button from '@/app/_components/ui/button';
+import { useConfirmEmail } from '../_hooks/use-confirm-email';
+import { AxiosError } from 'axios';
+
+type VerificationStatus = 'loading' | 'success' | 'error';
+
+const TOKEN_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const MAX_TOKEN_LENGTH = 512;
+
+function isValidTokenFormat(token: string): boolean {
+  return token.length > 0 && token.length <= MAX_TOKEN_LENGTH && TOKEN_PATTERN.test(token);
+}
+
+export default function VerifyEmailContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const token = searchParams.get('token');
+  const hasAttemptedRef = useRef(false);
+
+  const [status, setStatus] = useState<VerificationStatus>('loading');
+  const [errorMessage, setErrorMessage] = useState<string>('');
+
+  const { mutate: confirmEmail } = useConfirmEmail({
+    onSuccess: () => {
+      setStatus('success');
+    },
+    onError: (error) => {
+      setStatus('error');
+      if (error instanceof AxiosError) {
+        if (error.response?.status === 400) {
+          setErrorMessage('Token inválido ou expirado.');
+        } else if (error.response?.status === 404) {
+          setErrorMessage('Verificação não encontrada.');
+        } else {
+          setErrorMessage('Erro ao verificar email. Tente novamente.');
+        }
+      } else {
+        setErrorMessage('Erro ao verificar email. Tente novamente.');
+      }
+    },
+  });
+
+  useEffect(() => {
+    if (hasAttemptedRef.current) {
+      return;
+    }
+
+    if (!token) {
+      setStatus('error');
+      setErrorMessage('Token de verificação não encontrado.');
+      return;
+    }
+
+    if (!isValidTokenFormat(token)) {
+      setStatus('error');
+      setErrorMessage('Formato de token inválido.');
+      return;
+    }
+
+    hasAttemptedRef.current = true;
+    confirmEmail({ token });
+  }, [token, confirmEmail]);
+
+  return (
+    <div className='flex w-full max-w-[467px] flex-col items-center text-center'>
+      {status === 'loading' && (
+        <>
+          <div
+            className='mb-6 h-16 w-16 animate-spin rounded-full border-4 border-solid border-accent border-e-transparent'
+            role='status'
+          >
+            <span className='sr-only'>Verificando...</span>
+          </div>
+          <h1 className='text-2xl font-bold text-accent sm:text-3xl'>
+            Verificando seu email...
+          </h1>
+          <p className='mt-2 text-content-300'>
+            Aguarde enquanto confirmamos seu email.
+          </p>
+        </>
+      )}
+
+      {status === 'success' && (
+        <>
+          <CheckCircle size={64} className='mb-6 text-success' weight='fill' />
+          <h1 className='text-2xl font-bold text-accent sm:text-3xl'>
+            Email verificado!
+          </h1>
+          <p className='mt-2 text-content-300'>
+            Sua conta foi verificada com sucesso. Você já pode fazer login.
+          </p>
+          <Button
+            type='button'
+            aria-label='Ir para login'
+            label='Ir para login'
+            className='mt-8 w-full lg:w-72'
+            icon={<SignIn size={28} />}
+            onClick={() => router.push('/auth/login')}
+          />
+        </>
+      )}
+
+      {status === 'error' && (
+        <>
+          <XCircle size={64} className='mb-6 text-error' weight='fill' />
+          <h1 className='text-2xl font-bold text-accent sm:text-3xl'>
+            Erro na verificação
+          </h1>
+          <p className='mt-2 text-content-300'>{errorMessage}</p>
+          <Button
+            type='button'
+            aria-label='Ir para login'
+            label='Ir para login'
+            className='mt-8 w-full lg:w-72'
+            icon={<SignIn size={28} />}
+            onClick={() => router.push('/auth/login')}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/auth/verify-email/_hooks/use-confirm-email.test.tsx
+++ b/app/auth/verify-email/_hooks/use-confirm-email.test.tsx
@@ -1,0 +1,113 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useConfirmEmail } from './use-confirm-email';
+import * as accountMutations from '../../../_entities/account/mutations';
+import { AxiosError } from 'axios';
+import { ReactNode } from 'react';
+
+jest.mock('../../../_entities/account/mutations');
+
+const mockAccountMutations = accountMutations as jest.Mocked<typeof accountMutations>;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe('useConfirmEmail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls confirmEmailVerification mutation on success', async () => {
+    mockAccountMutations.confirmEmailVerification.mockResolvedValue(undefined);
+
+    const onSuccess = jest.fn();
+    const { result } = renderHook(() => useConfirmEmail({ onSuccess }), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ token: 'valid-token' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockAccountMutations.confirmEmailVerification).toHaveBeenCalledWith({
+      token: 'valid-token',
+    });
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('calls onError callback on failure', async () => {
+    const axiosError = new AxiosError('Bad Request');
+    axiosError.response = { status: 400 } as AxiosError['response'];
+    mockAccountMutations.confirmEmailVerification.mockRejectedValue(axiosError);
+
+    const onError = jest.fn();
+    const { result } = renderHook(() => useConfirmEmail({ onError }), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ token: 'invalid-token' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(onError).toHaveBeenCalledWith(axiosError);
+  });
+
+  it('returns isPending true while mutation is in progress', async () => {
+    let resolveConfirm: (value: unknown) => void;
+    mockAccountMutations.confirmEmailVerification.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveConfirm = resolve;
+        })
+    );
+
+    const { result } = renderHook(() => useConfirmEmail(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ token: 'test-token' });
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(true);
+    });
+
+    resolveConfirm!(undefined);
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+  });
+
+  it('does not call onSuccess on failure', async () => {
+    mockAccountMutations.confirmEmailVerification.mockRejectedValue(new Error('Error'));
+
+    const onSuccess = jest.fn();
+    const { result } = renderHook(() => useConfirmEmail({ onSuccess }), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ token: 'test-token' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/app/auth/verify-email/_hooks/use-confirm-email.ts
+++ b/app/auth/verify-email/_hooks/use-confirm-email.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import { confirmEmailVerification } from '@/app/_entities/account/mutations';
+import { ConfirmEmailRequest } from '@/app/_entities/account/model';
+
+interface UseConfirmEmailOptions {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+}
+
+export function useConfirmEmail(options?: UseConfirmEmailOptions) {
+  return useMutation({
+    mutationFn: (data: ConfirmEmailRequest) => confirmEmailVerification(data),
+    onSuccess: () => {
+      options?.onSuccess?.();
+    },
+    onError: (error: Error) => {
+      options?.onError?.(error);
+    },
+  });
+}

--- a/app/auth/verify-email/page.tsx
+++ b/app/auth/verify-email/page.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from 'react';
+import HorizontalLayout from '@/app/_components/horizontal-layout';
+import VerifyEmailContent from './_components/verify-email-content';
+
+function LoadingFallback() {
+  return (
+    <div className='flex w-full max-w-[467px] flex-col items-center text-center'>
+      <div
+        className='mb-6 h-16 w-16 animate-spin rounded-full border-4 border-solid border-accent border-e-transparent'
+        role='status'
+      >
+        <span className='sr-only'>Carregando...</span>
+      </div>
+      <h1 className='text-2xl font-bold text-accent sm:text-3xl'>
+        Carregando...
+      </h1>
+    </div>
+  );
+}
+
+export default function VerifyEmailPage() {
+  return (
+    <HorizontalLayout>
+      <Suspense fallback={<LoadingFallback />}>
+        <VerifyEmailContent />
+      </Suspense>
+    </HorizontalLayout>
+  );
+}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -16,6 +16,17 @@ const config: Config = {
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths),
   modulePaths: ['<rootDir>'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  // Coverage configuration
+  collectCoverageFrom: [
+    'app/**/*.{ts,tsx}',
+    '!app/**/*.d.ts',
+    '!app/**/*.test.{ts,tsx}',
+    '!app/**/index.ts',
+    '!app/layout.tsx',
+    '!app/**/page.tsx',
+  ],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov', 'json-summary'],
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,10 @@
+sonar.projectKey=buddy-client
+sonar.projectName=Buddy Client
+
+sonar.sources=app
+sonar.tests=app
+sonar.test.inclusions=**/*.test.ts,**/*.test.tsx
+sonar.exclusions=**/*.test.ts,**/*.test.tsx,**/node_modules/**,**/.next/**
+
+sonar.typescript.lcov.reportPaths=coverage/lcov.info
+sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,5 @@
-sonar.projectKey=buddy-client
+sonar.projectKey=genesluna_buddy-client
+sonar.organization=genesluna
 sonar.projectName=Buddy Client
 
 # Source configuration

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,10 +1,16 @@
 sonar.projectKey=buddy-client
 sonar.projectName=Buddy Client
 
-sonar.sources=app
-sonar.tests=app
-sonar.test.inclusions=**/*.test.ts,**/*.test.tsx
-sonar.exclusions=**/*.test.ts,**/*.test.tsx,**/node_modules/**,**/.next/**
+# Source configuration
+sonar.sources=.
+sonar.inclusions=app/**/*.ts,app/**/*.tsx
+sonar.exclusions=**/*.test.ts,**/*.test.tsx,**/node_modules/**,**/.next/**,**/coverage/**
 
-sonar.typescript.lcov.reportPaths=coverage/lcov.info
+# Test configuration
+sonar.tests=.
+sonar.test.inclusions=app/**/*.test.ts,app/**/*.test.tsx
+
+# Coverage configuration
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.typescript.lcov.reportPaths=coverage/lcov.info
+sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx,**/index.ts,app/layout.tsx,app/**/page.tsx


### PR DESCRIPTION
## Summary
- Add account entity layer with types (`AccountRequest`, `ConfirmEmailRequest`) and API mutations (`registerAccount`, `requestEmailVerification`, `confirmEmailVerification`)
- Update registration form with email, phone number (digits only), password (6-16 chars), and terms of service consent fields
- Implement `/auth/verify-email` page that validates token from URL and confirms email verification
- Add `/auth/verification-pending` page with resend verification email functionality

## Test plan
- [ ] Registration form validates all fields correctly
- [ ] Phone number only accepts digits (4-20 characters)
- [ ] Password validation (6-16 characters) works
- [ ] Terms must be accepted to submit
- [ ] Successful registration redirects to verification-pending page
- [ ] Email verification page handles valid/invalid tokens
- [ ] Resend verification email works
- [ ] API error messages display correctly (409 for duplicate email, 429 for rate limit)
- [ ] All new unit tests pass (`pnpm test`)
- [ ] Build succeeds (`pnpm build`)
- [ ] Lint passes (`pnpm lint`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end user registration with email, phone, password and terms consent
  * Verification-pending screen with resend verification capability
  * Email confirmation flow via verification link with clear success/error states

* **Validation**
  * Robust client-side form schemas with detailed field checks and cross-field validation

* **Tests**
  * Added tests covering registration flows, resend/confirm mutations, and validation rules

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->